### PR TITLE
mobile: default trail information is populated by trailhead info

### DIFF
--- a/js/trailhead.js
+++ b/js/trailhead.js
@@ -303,7 +303,7 @@ function startup() {
             addTrailsToTrailheads(originalTrailData, originalTrailheads);
             if (SMALL) {
               highlightTrailhead(orderedTrails[0].trailheadID, 0);
-              showTrailDetails(orderedTrails[0].trailhead, orderedTrails[0].trail);
+              showTrailDetails(orderedTrails[0].trail, orderedTrails[0].trailhead);
             }
           }
         });
@@ -1040,7 +1040,7 @@ function startup() {
     if (SMALL && USE_LOCAL) {
       highlightTrailhead(orderedTrails[0].trailheadID, 0);
       orderedTrailIndex = 0;
-      showTrailDetails(orderedTrails[0].trailhead, orderedTrails[0].trail);
+      showTrailDetails(orderedTrails[0].trail, orderedTrails[0].trailhead);
     }
   }
 


### PR DESCRIPTION
- on mobile, we 'select' the trail nearest to you by default.
- data about that trail is not being applied to the detail panel correctly. Trailhead information is applied to the trailName div, and no data is applied to the TrailheadName.

That's the crux. I'll flesh it out more as I dig in.
