### PR TITLE
should disable search/filter until trails are loaded.

### DIFF
--- a/js/trailhead.js
+++ b/js/trailhead.js
@@ -300,9 +300,9 @@ function startup() {
             });
           } else {
             addTrailsToTrailheads(originalTrailData, originalTrailheads);
-            if (SMALL) {
-              highlightTrailhead(orderedTrails[0].trailheadID, 0);
-              showTrailDetails(orderedTrails[0].trail, orderedTrails[0].trailhead);
+            if (SMALL &&($(".slideDrawer").hasClass("closedDrawer")) ){
+                highlightTrailhead(orderedTrails[0].trailheadID, 0);
+                showTrailDetails(orderedTrails[0].trail, orderedTrails[0].trailhead);
             }
           }
         });
@@ -1188,6 +1188,8 @@ function startup() {
     console.log("makeTrailDivs");
     orderedTrails = [];
     var divCount = 1;
+    if(myTrailheads.length === 0) return;
+
     $(".trailList").html("");
     for (var j = 0; j < myTrailheads.length; j++) {
       var trailhead = myTrailheads[j];


### PR DESCRIPTION
If you type something into search immediately on load, and before the trail data is fetched, the trail count stays at 0 until you change the search/filters again.
Should probably just disable the search/filter controls until makeTrailDivs finishes and we know everything is ready to go. If there's a common class containing all of them it should be pretty easy. Either disable them at the top of trailhead.js or in index.html itself, and enable them at the end of makeTrailDivs.
