### PR TITLE
Change map container background to light gray.

### DIFF
--- a/styles/css/main.css
+++ b/styles/css/main.css
@@ -45,6 +45,7 @@
 /**/
 /* Most Text */
 /* Yellows/Reds For Alerts */
+/* UI */
 /* Typography */
 @font-face {
   font-family: 'mission_gothicbold';
@@ -2078,6 +2079,7 @@ At some point, update mediaqueries to be in EMS
   cursor: pointer;
 }
 .trailMapContainer {
+  background: #dddddd;
   /* Desktop */
 
 }
@@ -3842,8 +3844,6 @@ html {
   /* 1 */
 
   -webkit-text-size-adjust: 100%;
-  /* 2 */
-
   -ms-text-size-adjust: 100%;
   /* 2 */
 

--- a/styles/less/colors.less
+++ b/styles/less/colors.less
@@ -91,3 +91,7 @@
 @color-yellow: #F3CA64;
 @color-light-red: #BE6E5C;
 @color-red: #9C2D23;
+
+/* UI */
+
+@color-map-background: #DDDDDD;

--- a/styles/less/map.less
+++ b/styles/less/map.less
@@ -306,6 +306,8 @@
 }
 
 .trailMapContainer {
+	background: @color-map-background;
+
 	@media @mobile {
 		position: absolute;
 		top: 48px; /* size of header */


### PR DESCRIPTION
This prevents the page looking weird and incomplete when it loads. The map switches to gray anyway once it starts loading the tiles, so this just accelerates this.

Screenshot of the “before” situation with white background:
![screen shot 2013-11-11 at 11 48 50 am](https://f.cloud.github.com/assets/2061609/1515930/26194e0a-4b0b-11e3-9faf-19e5f8ffc4f5.png)
