### PR TITLE
Public site locking up

### DIFF
--- a/js/trailhead.js
+++ b/js/trailhead.js
@@ -232,6 +232,10 @@ function startup() {
   // Kick things off
 
   showOverlay();
+
+  if ($("html").hasClass("lt-ie8")) {
+     return;  //abort, dont load
+  }
   initialSetup();
 
   // =====================================================================//


### PR DESCRIPTION
The public site access is freezing computers/explorer when trying to exit out of site. 
